### PR TITLE
Melpa recipe fixes

### DIFF
--- a/aws-athena-babel.el
+++ b/aws-athena-babel.el
@@ -46,7 +46,8 @@
 (require 'subr-x)
 
 
-(defvar aws-athena-babel-query-file "/tmp/athena-query.sql"
+(defvar aws-athena-babel-query-file
+  (expand-file-name "athena-query.sql" (temporary-file-directory))
   "Path to the temporary file where the Athena SQL query is stored.")
 
 (defvar aws-athena-babel-output-location "s3://my-bucket/"
@@ -77,7 +78,8 @@ For example: \"s3://my-bucket/path/\".")
 (defvar aws-athena-babel-console-region "us-east-2"
   "AWS region used to construct Athena Console URLs.")
 
-(defvar aws-athena-babel-csv-output-dir "/tmp"
+(defvar aws-athena-babel-csv-output-dir
+  (temporary-file-directory)
   "Directory where downloaded Athena CSV result files will be saved.")
 
 (defvar aws-athena-babel-monitor-mode-map
@@ -566,7 +568,7 @@ This is to cleaned field values."
 Display with tab, newline, and quote escape sequences removed."
   (interactive)
   (let* ((query-id (buffer-local-value 'aws-athena-babel-query-id (current-buffer)))
-         (csv-path (format "/tmp/%s.csv" query-id)))
+         (csv-path (expand-file-name (format "%s.csv" query-id) (temporary-file-directory))))
     (if (not (file-exists-p csv-path))
         (message "CSV file not found: %s" csv-path)
       (let ((buf (get-buffer-create "*Athena Raw Results*")))
@@ -611,7 +613,7 @@ Display with tab, newline, and quote escape sequences removed."
   "Open the local CSV result file for the current Athena query."
   (interactive)
   (let* ((query-id (buffer-local-value 'aws-athena-babel-query-id (current-buffer)))
-         (csv-path (format "/tmp/%s.csv" query-id)))
+         (csv-path (expand-file-name (format "%s.csv" query-id) (temporary-file-directory))))
     (if (not (file-exists-p csv-path))
         (message "CSV result not found: %s" csv-path)
       (find-file csv-path))))

--- a/aws-athena-babel.el
+++ b/aws-athena-babel.el
@@ -45,6 +45,7 @@
 (require 'json)
 (require 'subr-x)
 
+(declare-function persp-add-buffer "persp-mode.el")
 
 (defvar aws-athena-babel-query-file
   (expand-file-name "athena-query.sql" (temporary-file-directory))

--- a/aws-athena-babel.el
+++ b/aws-athena-babel.el
@@ -41,6 +41,7 @@
 
 ;;; Code:
 
+(require 'org)
 (require 'json)
 (require 'subr-x)
 


### PR DESCRIPTION
add fixes for serveral warnings for requiring org mode:
 aws-athena-babel.el:100:15: Warning: reference to free variable `org-src-lang-modes'
aws-athena-babel.el:100:15: Warning: assignment to free variable `org-src-lang-modes'

fixes for persps mode warnings:
aws-athena-babel.el:154:6: Warning: the function `persp-add-buffer' is not known to be defined.

use better temp directory function:
- aws-athena-babel.el#L48: Use `(temporary-file-directory)` instead of /tmp in code
- aws-athena-babel.el#L428: Use `(temporary-file-directory)` instead of /tmp in code
- aws-athena-babel.el#L568: Use `(temporary-file-directory)` instead of /tmp in code
- aws-athena-babel.el#L613: Use `(temporary-file-directory)` instead of /tmp in code
