### PR TITLE
Fix output directory bug and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,15 @@
 - CSV and JSON views with dedicated keybindings
 - Supports result reuse with Athena Workgroups
 - Displays full Athena Console URLs for easy web access
+- Provides local raw result file (`/tmp/<query-id>.csv`) for inspection or scripting
+- Displays a direct AWS Console link to the query execution
+- Default CSV output directory is the system temporary directory (as returned by `temporary-file-directory`)
 - Keybindings for quick actions:
   - `C-c C-k`: Cancel running query
   - `C-c C-c`: Show raw CSV output
-  - `C-c C-j`: Show JSON output (for Cloudtrail Buckets)
+  - `C-c C-j`: Show JSON output (for CloudTrail buckets)
+  - `C-c C-a`: Open Athena Console link in browser
+  - `C-c C-l`: Open local CSV result in Emacs
 
 ## Requirements
 
@@ -64,8 +69,8 @@ If you're using `use-package` in your Emacs config, you can load `aws-athena-bab
         aws-athena-babel-result-reuse-enabled t
         aws-athena-babel-result-reuse-max-age 10080
         aws-athena-babel-console-region "us-east-1"
-        aws-athena-babel-csv-output-dir "/tmp")
-   ```
+        aws-athena-babel-csv-output-dir "/my-result-directory"))
+```
 
 ## Usage
 
@@ -81,14 +86,17 @@ If you're using `use-package` in your Emacs config, you can load `aws-athena-bab
 
 3. Monitor progress in `*Athena Monitor*`, view CSV or JSON with keybindings.
 
-4. Results are saved to `/tmp/<query-id>.csv` and also rendered in Org-mode format.
+4. Results are by default saved to `/tmp/<query-id>.csv` and also rendered in Org-mode table format.
 
 ## Output Rendering
 
 - **Org Table**: Console-style format based on Athena's CSV output.
 - **CSV**: Raw download from S3, shown in a dedicated buffer.
 - **JSON**: Parsed and cleaned from CSV into structured objects.
-*The queries and the outputs have solely been tested with cloudtrail buckets*
+- **Local CSV**: Saved to system temp dir and openable with `C-c C-l`
+- **Console Link**: Openable in browser via `C-c C-a`
+
+*The queries and the outputs have solely been tested with CloudTrail buckets.*
 
 ## License
 

--- a/aws-athena-babel.el
+++ b/aws-athena-babel.el
@@ -429,7 +429,7 @@ Use CSV-PATH and QUERY-ID from the Athena query results."
 Display it in a formatted buffer."
   (interactive)
   (let* ((query-id (buffer-local-value 'aws-athena-babel-query-id (current-buffer)))
-         (csv-path (expand-file-name (format "%s.csv" query-id) (temporary-file-directory))))
+         (csv-path (expand-file-name (format "%s.csv" query-id) aws-athena-babel-csv-output-dir)))
     (if (not (file-exists-p csv-path))
         (message "CSV file not found: %s" csv-path)
       (aws-athena-babel--render-json-buffer csv-path))))
@@ -569,7 +569,7 @@ This is to cleaned field values."
 Display with tab, newline, and quote escape sequences removed."
   (interactive)
   (let* ((query-id (buffer-local-value 'aws-athena-babel-query-id (current-buffer)))
-         (csv-path (expand-file-name (format "%s.csv" query-id) (temporary-file-directory))))
+         (csv-path (expand-file-name (format "%s.csv" query-id) aws-athena-babel-csv-output-dir)))
     (if (not (file-exists-p csv-path))
         (message "CSV file not found: %s" csv-path)
       (let ((buf (get-buffer-create "*Athena Raw Results*")))
@@ -614,7 +614,7 @@ Display with tab, newline, and quote escape sequences removed."
   "Open the local CSV result file for the current Athena query."
   (interactive)
   (let* ((query-id (buffer-local-value 'aws-athena-babel-query-id (current-buffer)))
-         (csv-path (expand-file-name (format "%s.csv" query-id) (temporary-file-directory))))
+         (csv-path (expand-file-name (format "%s.csv" query-id) aws-athena-babel-csv-output-dir)))
     (if (not (file-exists-p csv-path))
         (message "CSV result not found: %s" csv-path)
       (find-file csv-path))))


### PR DESCRIPTION
 This fixes the issue when trying to use a custom output directory before there was an issue that it was using the temp directory at all times when it should just be whatever the user provided. It also updates the documentation to add the new keybinds and other minor changes.